### PR TITLE
Added $PATH append so that previous path settings are kept

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -54,7 +54,7 @@ source $ZSH/oh-my-zsh.sh
 
 # User configuration
 
-export PATH="/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin:/opt/X11/bin"
+export PATH=$PATH:"/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin:/opt/X11/bin"
 # export MANPATH="/usr/local/man:$MANPATH"
 
 # You may need to manually set your language environment


### PR DESCRIPTION
The path should not be overridden in the .zshrc in case something else is setting the $PATH prior to the zshrc being sourced.
